### PR TITLE
removed direct access to pouchdb-adapter-websql-core

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var WebSqlPouchCore = require('pouchdb-adapter-websql-core')
 var extend = require('js-extend').extend
 var guardedConsole = require('pouchdb-utils').guardedConsole
 
@@ -27,32 +26,40 @@ function createOpenDBFunction (opts) {
   }
 }
 
-function CordovaSQLitePouch (opts, callback) {
-  var websql = createOpenDBFunction(opts)
-  var _opts = extend({
-    websql: websql
-  }, opts)
+module.exports = function (PouchDB) {
+  var WebSqlPouchCore = PouchDB.adapters['websql']
 
-  if (typeof cordova === 'undefined' || typeof sqlitePlugin === 'undefined' || typeof openDatabase === 'undefined') {
-    guardedConsole('error',
-      'PouchDB error: you must install a SQLite plugin ' +
-      'in order for PouchDB to work on this platform. Options:' +
-      '\n - https://github.com/nolanlawson/cordova-plugin-sqlite-2' +
-      '\n - https://github.com/litehelpers/Cordova-sqlite-storage' +
-      '\n - https://github.com/Microsoft/cordova-plugin-websql')
+  function CordovaSQLitePouch (opts, callback) {
+    var websql = createOpenDBFunction(opts)
+    var _opts = extend({
+      websql: websql
+    }, opts)
+
+    if (typeof cordova === 'undefined' || typeof sqlitePlugin === 'undefined' || typeof openDatabase === 'undefined') {
+      guardedConsole('error',
+        'PouchDB error: you must install a SQLite plugin ' +
+        'in order for PouchDB to work on this platform. Options:' +
+        '\n - https://github.com/nolanlawson/cordova-plugin-sqlite-2' +
+        '\n - https://github.com/litehelpers/Cordova-sqlite-storage' +
+        '\n - https://github.com/Microsoft/cordova-plugin-websql')
+    }
+
+    if(!WebSqlPouchCore) {
+      guardedConsole('error',
+        'PouchDB error: you must install the websql plugin')
+      return
+    }
+
+    WebSqlPouchCore.call(this, _opts, callback)
   }
 
-  WebSqlPouchCore.call(this, _opts, callback)
-}
+  CordovaSQLitePouch.valid = function () {
+    // if you're using Cordova, we assume you know what you're doing because you control the environment
+    return true
+  }
 
-CordovaSQLitePouch.valid = function () {
-  // if you're using Cordova, we assume you know what you're doing because you control the environment
-  return true
-}
+  // no need for a prefix in cordova (i.e. no need for `_pouch_` prefix
+  CordovaSQLitePouch.use_prefix = false
 
-// no need for a prefix in cordova (i.e. no need for `_pouch_` prefix
-CordovaSQLitePouch.use_prefix = false
-
-module.exports = function (PouchDB) {
   PouchDB.adapter('cordova-sqlite', CordovaSQLitePouch, true)
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "js-extend": "1.0.1",
-    "pouchdb-adapter-websql-core": "^5.4.5",
     "pouchdb-utils": "^5.4.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi.

I’m using pouchdb-adapter-cordova-sqlite in an Ionic2 (RC0) project. Pouchdb and pouchdb-adapter-cordova-sqlite are included as npm packages (In opposite to the way it’s done in your pouchdb-adapter-cordova-sqlite-demo).

In npm dependencies, I have included:
```
    "pouchdb-adapter-cordova-sqlite": "^1.0.0",
    "pouchdb-browser": "^6.0.6",
```
In declarations.d.ts:
```
declare module 'pouchdb-adapter-cordova-sqlite' {
    const PouchAdapterCordovaSqlite: PouchDB.Plugin;
    export = PouchAdapterCordovaSqlite;
}
```
In app.component.ts:
```
import PouchDB from 'pouchdb-browser';
import PouchAdapterCordovaSqlite from 'pouchdb-adapter-cordova-sqlite';
PouchDB.plugin(PouchAdapterCordovaSqlite);
```

This makes the bundler(Rollup) include all code from pouchdb-adapter-cordova-sqlite and its dependencies in the compiled main.js. Unfortunately, the bundler doesn’t respect the npm browser field and I get node.js code included in the bundle resulting in very strange errors in the app.

In this PR, I have removed direct access to pouchdb-adapter-websql-core resulting in not including node.js code anymore. Please look in you can integrate it in the main repo
